### PR TITLE
Fix to where express was throwing an error when loading website

### DIFF
--- a/Project code/.env
+++ b/Project code/.env
@@ -2,3 +2,6 @@
 POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="pwd"
 POSTGRES_DB="users_db"
+
+SESSION_SECRET="Placeholder"
+API_KEY=""

--- a/Project code/src/index.js
+++ b/Project code/src/index.js
@@ -14,7 +14,7 @@ const dbConfig = {
     user: process.env.POSTGRES_USER,
     password: process.env.POSTGRES_PASSWORD,
   };
-  
+
 const db = pgp(dbConfig);
   
   // test your database
@@ -44,3 +44,11 @@ app.use(
   );
 app.listen(3000);
 console.log('Server is listening on port 3000');
+
+app.get('/', (req, res) =>{
+  res.redirect('/login'); 
+});
+
+app.get('/login', (req, res) => {
+  res.render('pages/login');
+}); 


### PR DESCRIPTION
Express required a session_secret placeholder for it to run with Index.js. This has been fixed. The website now also directs to the login page on load.